### PR TITLE
Fix Evaluate logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,20 @@ Flags:
   -p, --port string        The port of the HTTP server
 ```
 
-## Eval a policy
+## Evaluate the input by a policy list
+
+Only `allow` and `deny` will be evaluated. If the variable `allow` be evaluated as false, or the variable `deny` be 
+evaluated as true, The policy will be evaluated as false.
 
 ```shell
 $ curl -X POST http://localhost:8080/evaluate/policies -H 'Content-Type: application/json' -d '
 {
-    "rego_list": [{
-            "policy": "import future.keywords.if\nimport future.keywords.in\n\ndefault allow := false\n\nallow if {\n    input.method == \"GET\"\n    input.path == [\"salary\", input.subject.user]\n}\n\nallow if is_admin\n\nis_admin if \"admin\" in input.subject.groups",
-            "isAllow": true
-        }
+    "policy_list": [
+        "import future.keywords.if\nimport future.keywords.in\n\ndefault allow := false\n\nallow if {\n    input.method == \"GET\"\n    input.path == [\"salary\", input.subject.user]\n}\n\nallow if is_admin\n\nis_admin if \"admin\" in input.subject.groups",
+        "import future.keywords.if\nimport future.keywords.in\n\ndefault deny := false\n\nallow if {\n    input.method == \"GET\"\n    input.path == [\"salary\", input.subject.user]\n}\n\nallow if is_admin\n\nis_admin if \"admin\" in input.subject.groups"
     ],
-     "input": "{\"method\":\"GET\",\"path\":[\"salary\",\"bob\"],\"subject\":{\"user\":\"bob\",\"groups\":[\"sales\",\"marketing\"]}}"
- }'
+    "input": "{\"method\":\"GET\",\"path\":[\"salary\",\"bob\"],\"subject\":{\"user\":\"bob\",\"groups\":[\"sales\",\"marketing\"]}}"
+}'
  
 {"isSuccessful":true}
 ```

--- a/log/log.go
+++ b/log/log.go
@@ -33,12 +33,12 @@ func InitLog(level, path string) error {
 		basic.SetFormatter(&logrus.JSONFormatter{})
 	} else {
 		basic.Formatter = &logrus.TextFormatter{
-			TimestampFormat: "2023/01/01 - 01:01:01",
+			TimestampFormat: "2006/01/02 - 15:04:05",
 			FullTimestamp:   true,
 		}
 
 		basic.Formatter = &logrus.TextFormatter{
-			TimestampFormat: "2023/01/01 - 01:01:01",
+			TimestampFormat: "2006/01/02 - 15:04:05",
 			FullTimestamp:   true,
 		}
 	}

--- a/server/handle_common.go
+++ b/server/handle_common.go
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package server
+
+import "github.com/gin-gonic/gin"
+
+type ErrorResult struct {
+	ErrCode int    `json:"err_code,omitempty"`
+	ErrMsg  string `json:"err_msg,omitempty"`
+}
+
+func abortWithError(c *gin.Context, code int, message string) {
+	c.AbortWithStatusJSON(code, ErrorResult{
+		ErrCode: code,
+		ErrMsg:  message,
+	})
+}

--- a/server/handle_health.go
+++ b/server/handle_health.go
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * SPDX-FileCopyrightText: Huawei Inc.
+ */
+
+package server
+
+import "github.com/gin-gonic/gin"
+
+type HealthStatus string
+
+const (
+	healthOk HealthStatus = "OK"
+)
+
+type HealthStatusResponse struct {
+	HealthStatus HealthStatus `json:"healthStatus"`
+}
+
+func healthHandler(c *gin.Context) {
+	c.JSON(200, HealthStatusResponse{
+		HealthStatus: healthOk,
+	})
+	return
+}


### PR DESCRIPTION
related to eclipse-xpanse/xpanse#896
related to eclipse-xpanse/xpanse#900

Remove the `isAllow` from the request and response.

As the opa will try to evaluate all the variables into the `bindings`,  we just need to care about the `allow` and the `deny` variables in the rego. If no such variables, this rego will be ignored.

```
$ opa eval --data policy.rego --input input.json "result=data.example.auth"
{
  "result": [
    {
      "expressions": [
        {
          "value": true,
          "text": "result=data.example.auth",
          "location": {
            "row": 1,
            "col": 1
          }
        }
      ],
      "bindings": {
        "result": {
          "allow": true,
          "deny": true,
          "x": 1,
          "y": "hello world"
        }
      }
    }
  ]
}
```